### PR TITLE
Optimize GNU/Linux compile

### DIFF
--- a/anitorrent-native/CMakeLists.txt
+++ b/anitorrent-native/CMakeLists.txt
@@ -53,7 +53,7 @@ else ()
 	# 尝试引入 GNU/Linux 发行版下的编译
     if (UNIX AND NOT APPLE AND NOT WIN32)
         # 添加 Linux 平台下的额外配置
-		add_compile_options(-Wall -Wextra -std=c++17 -g -O2 -pthread -fPIC -fno-exceptions -frtti)
+		add_compile_options(-Wall -Wextra -std=c++17 -O2 -pthread -fPIC -fno-exceptions -frtti)
 		set(BUILD_SHARED_LIBS OFF) # 编译 libtorrent 为静态库
 		set(OPENSSL_USE_STATIC_LIBS TRUE) # 静态链接 OpenSSL
         find_package(OpenSSL REQUIRED)


### PR DESCRIPTION
## Description

### What does this Pull Request do?

This Pull Request is about optimizing the compile process of GNU/Linux platform to reduce the large of the compile target file. Under a CI-Build test, we discovered that this will reduce the large of the compile target file to 4.4 MB(Jar file) and 14.4 MB(Native Library), which was 22.2 MB(Jar file) and 81.4 MB(Native Library) before optimization, same as Android, Windows and macOS platform.

### What we did?

In Anitorrent Native part, we did the list below:

1. Modify the [anitorrent/anitorrent-native/CMakeLists.txt](https://github.com/Kasumi-Ushioi/anitorrent/blob/main/anitorrent-native/CMakeLists.txt) to modify some of the compile arguments when compiling under a GNU/Linux platform.

### What we didn't do?

We didn't test the compatibility with the original Animeko about this modified project yet.

## 描述

### 这个 Pull Request 做了什么？

这个 Pull Request 聚焦于优化 GNU/Linux 平台下的编译流程，以减少编译产物大小。经过测试，这将使编译产物大小从原本的 22.2MB(Jar 文件) 和 81.4MB(原生库) 缩小至 4.4MB(Jar 文件) 和 14.4MB(原生库)，与其它平台(Android, Windows, macOS)保持一致。

### 我们都做了什么？

对 Anitorrent 的 Native 部分，我们做了以下更改：

1. 修改 [anitorrent/anitorrent-native/CMakeLists.txt](https://github.com/open-ani/anitorrent/blob/main/anitorrent-native/CMakeLists.txt) 以修改 GNU/Linux 平台下的编译选项，主要是去除调试符号。

### 我们没做什么？

我们尚未测试修改后的 Anitorrent 与原版 Animeko 项目的相容性。