### PR TITLE
添加 Windows ARM64 native runtime 支持

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,73 @@ jobs:
         path: 'anitorrent-native/build/native-jars/anitorrent-native-*.jar'
         if-no-files-found: 'error'
         overwrite: 'true'
+  build_github-windows-11-arm64:
+    name: 'Build (Windows 11 AArch64 (GitHub))'
+    runs-on:
+    - 'windows-11-arm'
+    permissions:
+      actions: 'write'
+    steps:
+    - id: 'step-0'
+      uses: 'actions/checkout@v4'
+      with:
+        submodules: 'recursive'
+    - id: 'step-1'
+      name: 'Setup JDK 21'
+      uses: 'actions/setup-java@v4'
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+      env:
+        GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+    - id: 'step-2'
+      run: 'echo "jvm.toolchain.version=21" >> local.properties'
+    - id: 'step-3'
+      name: 'Setup Android SDK'
+      uses: 'android-actions/setup-android@v3'
+      with:
+        accept-android-sdk-licenses: 'false'
+        packages: 'platform-tools'
+    - id: 'step-4'
+      name: 'Install Android platform'
+      run: |-
+        1..20 | ForEach-Object { "y" } | sdkmanager --licenses
+        sdkmanager "platforms;android-34"
+    - id: 'step-5'
+      name: 'Setup vcpkg cache'
+      uses: 'actions/github-script@v7'
+      with:
+        script: |-
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+    - id: 'step-6'
+      name: 'Install Native Dependencies for Windows'
+      env:
+        VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+      run: './ci-helper/install-deps-windows.cmd'
+    - id: 'step-7'
+      name: 'Setup Gradle'
+      uses: 'gradle/actions/setup-gradle@v3'
+      with:
+        cache-disabled: 'true'
+    - id: 'step-8'
+      name: 'Clean and download dependencies'
+      uses: 'nick-fields/retry@v2'
+      with:
+        timeout_minutes: '60'
+        max_attempts: '3'
+        command: './gradlew "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-Dani.enable.anitorrent=true" "-DCMAKE_BUILD_TYPE=Release" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/arm64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "-Pani.android.abis=arm64-v8a"'
+    - id: 'step-9'
+      name: 'Build anitorrent'
+      run: './gradlew buildAnitorrent copyNativeJarForCurrentPlatform "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-Dani.enable.anitorrent=true" "-DCMAKE_BUILD_TYPE=Release" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/arm64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "-Pani.android.abis=arm64-v8a"'
+    - id: 'step-10'
+      name: 'Upload Anitorrent'
+      uses: 'actions/upload-artifact@v4'
+      with:
+        name: 'anitorrent-windows-aarch64'
+        path: 'anitorrent-native/build/native-jars/anitorrent-native-*.jar'
+        if-no-files-found: 'error'
+        overwrite: 'true'
   build_github-ubuntu-2404:
     name: 'Build (Ubuntu 24.04 LTS x86_64)'
     runs-on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,90 @@ jobs:
         path: 'anitorrent-native/build/native-jars/anitorrent-native-*.jar'
         if-no-files-found: 'error'
         overwrite: 'true'
+  release_github-windows-11-arm64:
+    name: 'Windows 11 AArch64 (GitHub)'
+    runs-on:
+    - 'windows-11-arm'
+    needs:
+    - 'create-release'
+    steps:
+    - id: 'step-0'
+      uses: 'actions/checkout@v4'
+      with:
+        submodules: 'recursive'
+    - id: 'step-1'
+      name: 'Get Tag'
+      uses: 'dawidd6/action-get-tag@v1'
+    - id: 'step-2'
+      uses: 'bhowell2/github-substring-action@v1.0.0'
+      with:
+        value: '${{ steps.step-1.outputs.tag }}'
+        index_of_str: 'v'
+        default_return_value: '${{ steps.step-1.outputs.tag }}'
+    - id: 'step-3'
+      name: 'Setup JDK 21'
+      uses: 'actions/setup-java@v4'
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+      env:
+        GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+    - id: 'step-4'
+      run: 'echo "jvm.toolchain.version=21" >> local.properties'
+    - id: 'step-5'
+      name: 'Setup Android SDK'
+      uses: 'android-actions/setup-android@v3'
+      with:
+        accept-android-sdk-licenses: 'false'
+        packages: 'platform-tools'
+    - id: 'step-6'
+      name: 'Install Android platform'
+      run: |-
+        1..20 | ForEach-Object { "y" } | sdkmanager --licenses
+        sdkmanager "platforms;android-34"
+    - id: 'step-7'
+      name: 'Setup vcpkg cache'
+      uses: 'actions/github-script@v7'
+      with:
+        script: |-
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+    - id: 'step-8'
+      name: 'Install Native Dependencies for Windows'
+      env:
+        VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+      run: './ci-helper/install-deps-windows.cmd'
+    - id: 'step-9'
+      name: 'Setup Gradle'
+      uses: 'gradle/actions/setup-gradle@v3'
+      with:
+        cache-disabled: 'true'
+    - id: 'step-10'
+      name: 'Clean and download dependencies'
+      uses: 'nick-fields/retry@v2'
+      with:
+        timeout_minutes: '60'
+        max_attempts: '3'
+        command: './gradlew "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-Dani.enable.anitorrent=true" "-DCMAKE_BUILD_TYPE=Release" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/arm64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "-Pani.android.abis=arm64-v8a"'
+    - id: 'step-11'
+      name: 'Update Release Version Name'
+      env:
+        GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        GITHUB_REPOSITORY: '${{ secrets.GITHUB_REPOSITORY }}'
+        CI_RELEASE_ID: '${{ needs.create-release.outputs.id }}'
+        CI_TAG: '${{ steps.step-1.outputs.tag }}'
+      run: './gradlew updateReleaseVersionNameFromGit "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-Dani.enable.anitorrent=true" "-DCMAKE_BUILD_TYPE=Release" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/arm64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "-Pani.android.abis=arm64-v8a"'
+    - id: 'step-12'
+      name: 'Build anitorrent'
+      run: './gradlew buildAnitorrent copyNativeJarForCurrentPlatform "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-Dani.enable.anitorrent=true" "-DCMAKE_BUILD_TYPE=Release" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/arm64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "-Pani.android.abis=arm64-v8a"'
+    - id: 'step-13'
+      name: 'Upload Anitorrent'
+      uses: 'actions/upload-artifact@v4'
+      with:
+        name: 'anitorrent-windows-aarch64'
+        path: 'anitorrent-native/build/native-jars/anitorrent-native-*.jar'
+        if-no-files-found: 'error'
+        overwrite: 'true'
   release_self-hosted-macos-15:
     name: 'macOS 15 AArch64 (Self-Hosted)'
     runs-on:
@@ -274,6 +358,7 @@ jobs:
     needs:
     - 'create-release'
     - 'release_github-windows-2019'
+    - 'release_github-windows-11-arm64'
     - 'release_self-hosted-macos-15'
     - 'release_github-ubuntu-2404'
     steps:
@@ -348,16 +433,21 @@ jobs:
     - id: 'step-14'
       uses: 'actions/download-artifact@v4'
       with:
-        name: 'anitorrent-macos-aarch64'
+        name: 'anitorrent-windows-aarch64'
         path: 'anitorrent-native/build/native-jars'
     - id: 'step-15'
       uses: 'actions/download-artifact@v4'
       with:
-        name: 'anitorrent-ubuntu-x64'
+        name: 'anitorrent-macos-aarch64'
         path: 'anitorrent-native/build/native-jars'
     - id: 'step-16'
-      run: 'ls -l anitorrent-native/build/native-jars'
+      uses: 'actions/download-artifact@v4'
+      with:
+        name: 'anitorrent-ubuntu-x64'
+        path: 'anitorrent-native/build/native-jars'
     - id: 'step-17'
+      run: 'ls -l anitorrent-native/build/native-jars'
+    - id: 'step-18'
       env:
         ORG_GRADLE_PROJECT_mavenCentralUsername: '${{ secrets.ORG_GRADLE_PROJECT_mavenCentralUsername }}'
         ORG_GRADLE_PROJECT_mavenCentralPassword: '${{ secrets.ORG_GRADLE_PROJECT_mavenCentralPassword }}'

--- a/.github/workflows/src.main.kts
+++ b/.github/workflows/src.main.kts
@@ -54,6 +54,7 @@ import io.github.typesafegithub.workflows.domain.JobOutputs
 import io.github.typesafegithub.workflows.domain.Mode
 import io.github.typesafegithub.workflows.domain.Permission
 import io.github.typesafegithub.workflows.domain.RunnerType
+import io.github.typesafegithub.workflows.domain.actions.CustomAction
 import io.github.typesafegithub.workflows.domain.triggers.PullRequest
 import io.github.typesafegithub.workflows.domain.triggers.Push
 import io.github.typesafegithub.workflows.dsl.JobBuilder
@@ -196,7 +197,8 @@ class MatrixInstance(
 
         if (os == OS.WINDOWS) {
             add(quote("-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake"))
-            add(quote("-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include"))
+            val boostTriplet = if (arch == Arch.AARCH64) "arm64-windows" else "x64-windows"
+            add(quote("-DBoost_INCLUDE_DIR=C:/vcpkg/installed/$boostTriplet/include"))
         }
 
         add(quote("-Dorg.gradle.jvmargs=-Xmx${gradleHeap}"))
@@ -263,6 +265,14 @@ sealed class Runner(
         os = OS.WINDOWS,
         arch = Arch.X64,
         labels = setOf("windows-2022"),
+    )
+
+    object GithubWindows11Arm64 : GithubHosted(
+        id = "github-windows-11-arm64",
+        displayName = "Windows 11 AArch64 (GitHub)",
+        os = OS.WINDOWS,
+        arch = Arch.AARCH64,
+        labels = setOf("windows-11-arm"),
     )
 
     object GithubMacOS13 : GithubHosted(
@@ -359,6 +369,23 @@ val buildMatrixInstances = listOf(
         buildAllAndroidAbis = false,
     ),
     MatrixInstance(
+        runner = Runner.GithubWindows11Arm64,
+        uploadApk = false,
+        buildAnitorrent = true,
+        buildAnitorrentSeparately = false,
+        composeResourceTriple = "windows-arm64",
+        gradleHeap = "4g",
+        kotlinCompilerHeap = "4g",
+        gradleParallel = true,
+        // Windows ARM64 does not have the JDK 8 toolchain used by the desktop Kotlin target.
+        runTests = false,
+        uploadDesktopInstallers = true,
+        extraGradleArgs = listOf(
+            "-P$ANI_ANDROID_ABIS=arm64-v8a",
+        ),
+        buildAllAndroidAbis = false,
+    ),
+    MatrixInstance(
         runner = Runner.GithubUbuntu2404,
         name = "Ubuntu 24.04 LTS x86_64",
         uploadApk = false,
@@ -410,6 +437,7 @@ fun getBuildJobBody(matrix: MatrixInstance): JobBuilder<BuildJobOutputs>.() -> U
     with(WithMatrix(matrix)) {
         freeSpace()
         installJdk()
+        setupAndroidSdkForWindowsArm64()
         installNativeDeps()
         chmod777()
         setupGradle()
@@ -417,7 +445,7 @@ fun getBuildJobBody(matrix: MatrixInstance): JobBuilder<BuildJobOutputs>.() -> U
         gradleCheck()
         runGradle(
             name = "Build anitorrent",
-            tasks = ["buildAnitorrent", "copyNativeJarForCurrentPlatform"],
+            tasks = arrayOf("buildAnitorrent", "copyNativeJarForCurrentPlatform"),
         )
         uploadAnitorrent()
 
@@ -557,13 +585,14 @@ workflow(
 
                 freeSpace()
                 installJdk()
+                setupAndroidSdkForWindowsArm64()
                 installNativeDeps()
                 chmod777()
                 setupGradle()
 
                 runGradle(
                     name = "Update Release Version Name",
-                    tasks = ["updateReleaseVersionNameFromGit"],
+                    tasks = arrayOf("updateReleaseVersionNameFromGit"),
                     env = mapOf(
                         "GITHUB_TOKEN" to expr { secrets.GITHUB_TOKEN },
                         "GITHUB_REPOSITORY" to expr { secrets.GITHUB_REPOSITORY },
@@ -575,7 +604,7 @@ workflow(
 
                 runGradle(
                     name = "Build anitorrent",
-                    tasks = ["buildAnitorrent", "copyNativeJarForCurrentPlatform"],
+                    tasks = arrayOf("buildAnitorrent", "copyNativeJarForCurrentPlatform"),
                 )
                 // no check
                 uploadAnitorrent()
@@ -588,12 +617,14 @@ workflow(
     )
 
     val win = addJob(buildMatrixInstances[Runner.GithubWindowsServer2019])
+    val winArm64 = addJob(buildMatrixInstances[Runner.GithubWindows11Arm64])
     val macAarch64 = addJob(buildMatrixInstances[Runner.SelfHostedMacOS15])
     val ubuntu = addJob(buildMatrixInstances[Runner.GithubUbuntu2404])
-    addJob(buildMatrixInstances[Runner.GithubMacOS13], needs = listOf(win, macAarch64, ubuntu)) { matrix ->
+    addJob(buildMatrixInstances[Runner.GithubMacOS13], needs = listOf(win, winArm64, macAarch64, ubuntu)) { matrix ->
         with(WithMatrix(matrix)) {
             listOf(
                 OS.WINDOWS to Arch.X64,
+                OS.WINDOWS to Arch.AARCH64,
                 OS.MACOS to Arch.AARCH64,
                 OS.UBUNTU to Arch.X64,
             ).forEach { (os, arch) ->
@@ -607,7 +638,7 @@ workflow(
 
             run(command = "ls -l anitorrent-native/build/native-jars")
             runGradle(
-                tasks = ["publish"],
+                tasks = arrayOf("publish"),
                 env = mapOf(
                     "ORG_GRADLE_PROJECT_mavenCentralUsername" to expr { secrets["ORG_GRADLE_PROJECT_mavenCentralUsername"]!! },
                     "ORG_GRADLE_PROJECT_mavenCentralPassword" to expr { secrets["ORG_GRADLE_PROJECT_mavenCentralPassword"]!! },
@@ -735,6 +766,32 @@ class WithMatrix(
         }
     }
 
+    fun JobBuilder<*>.setupAndroidSdkForWindowsArm64() {
+        if (matrix.isWindowsAArch64) {
+            uses(
+                name = "Setup Android SDK",
+                action = CustomAction(
+                    actionOwner = "android-actions",
+                    actionName = "setup-android",
+                    actionVersion = "v3",
+                    inputs = mapOf(
+                        "accept-android-sdk-licenses" to "false",
+                        "packages" to "platform-tools",
+                    ),
+                ),
+            )
+            run(
+                name = "Install Android platform",
+                command = shell(
+                    """
+                    1..20 | ForEach-Object { "y" } | sdkmanager --licenses
+                    sdkmanager "platforms;android-34"
+                    """.trimIndent(),
+                ),
+            )
+        }
+    }
+
     fun JobBuilder<*>.chmod777() {
         if (matrix.isUnix) {
             run(
@@ -821,6 +878,7 @@ val MatrixInstance.isUnix get() = (os == OS.UBUNTU) or (os == (OS.MACOS))
 
 val MatrixInstance.isMacOSAArch64 get() = (os == OS.MACOS) and (arch == Arch.AARCH64)
 val MatrixInstance.isMacOSX64 get() = (os == OS.MACOS) and (arch == Arch.X64)
+val MatrixInstance.isWindowsAArch64 get() = (os == OS.WINDOWS) and (arch == Arch.AARCH64)
 
 // only for highlighting (though this does not work in KT 2.1.0)
 fun shell(@Language("shell") command: String) = command

--- a/anitorrent-native/CMakeLists.txt
+++ b/anitorrent-native/CMakeLists.txt
@@ -122,6 +122,7 @@ FetchContent_Declare(
         GIT_TAG v2.0.10
 )
 FetchContent_MakeAvailable(libtorrent)
+target_include_directories(torrent-rasterbar PRIVATE ${Boost_INCLUDE_DIR})
 
 if (NOT ANDROID)
     # JNI
@@ -156,7 +157,7 @@ add_library(anitorrent
         cpp/include/peer_filter.hpp
         cpp/src/peer_filter.cpp
 )
-target_include_directories(anitorrent PRIVATE cpp/include include)
+target_include_directories(anitorrent PRIVATE cpp/include include ${Boost_INCLUDE_DIR})
 
 # Link libraries
 if (ANDROID)

--- a/anitorrent-native/build.gradle.kts
+++ b/anitorrent-native/build.gradle.kts
@@ -272,10 +272,16 @@ val configureAnitorrent = tasks.register("configureAnitorrent", Exec::class.java
             add("Ninja")
         } else {
             getPropertyOrNull("CMAKE_TOOLCHAIN_FILE")?.let { add("-DCMAKE_TOOLCHAIN_FILE=${it.sanitize()}") }
+            if (getArch() == Arch.AARCH64) {
+                add("-DVCPKG_TARGET_TRIPLET=arm64-windows")
+            }
             if (getPropertyOrNull("USE_NINJA")?.toBooleanStrict() == true) {
                 add("-DCMAKE_MAKE_PROGRAM=${ninja.sanitize()}")
                 add("-G")
                 add("Ninja")
+            } else if (getArch() == Arch.AARCH64) {
+                add("-A")
+                add("ARM64")
             }
         }
         add("-S")
@@ -435,6 +441,16 @@ val copyNativeFiles by tasks.registering {
                         put("SSL_EAY_RELEASE_${index}", file)
                     }
                 }
+                map["OPENSSL_CRYPTO_LIBRARY:FILEPATH"]?.let {
+                    findDll(File(it)).forEachIndexed { index, file ->
+                        put("OPENSSL_CRYPTO_LIBRARY_${index}", file)
+                    }
+                }
+                map["OPENSSL_SSL_LIBRARY:FILEPATH"]?.let {
+                    findDll(File(it)).forEachIndexed { index, file ->
+                        put("OPENSSL_SSL_LIBRARY_${index}", file)
+                    }
+                }
             }
         }
 
@@ -450,7 +466,7 @@ tasks.withType(KotlinJvmCompile::class) {
     mustRunAfter(generateSwigImpl)
 }
 
-val supportedOsTriples = listOf("macos-aarch64", "macos-x64", "windows-x64", "linux-x64")
+val supportedOsTriples = listOf("macos-aarch64", "macos-x64", "windows-x64", "windows-arm64", "linux-x64")
 
 val nativeJarsDir = layout.buildDirectory.dir("native-jars")
 val nativeJarForCurrentPlatform = tasks.register("nativeJarForCurrentPlatform", Jar::class.java) {
@@ -504,7 +520,11 @@ afterEvaluate {
         publications {
             getByName("desktop", MavenPublication::class) {
                 val platforms = if (getLocalProperty("ani.publishing.onlyHostOS") == "true") {
-                    listOf("macos-aarch64")
+                    if (getOs() == Os.Windows && getArch() == Arch.AARCH64) {
+                        listOf(getOsTriple())
+                    } else {
+                        listOf("macos-aarch64")
+                    }
                 } else {
                     supportedOsTriples
                 }

--- a/buildSrc/src/main/kotlin/os.kt
+++ b/buildSrc/src/main/kotlin/os.kt
@@ -26,7 +26,7 @@ enum class Arch {
 fun getArch(): Arch {
     val arch = System.getProperty("os.arch").lowercase(Locale.getDefault())
     return when {
-        arch.contains("x86_64") -> Arch.X86_64
+        arch.contains("x86_64") || arch.contains("amd64") -> Arch.X86_64
         arch.contains("aarch64") || arch.contains("arm") -> Arch.AARCH64
         else -> throw UnsupportedOperationException("Unknown architecture: $arch")
     }
@@ -34,7 +34,7 @@ fun getArch(): Arch {
 
 fun getOsTriple(): String {
     return when (getOs()) {
-        Os.Windows -> "windows-x64"
+        Os.Windows -> if (getArch() == Arch.AARCH64) "windows-arm64" else "windows-x64"
         Os.MacOS -> if (getArch() == Arch.AARCH64) "macos-aarch64" else "macos-x64"
         Os.Linux -> "linux-x64"
         Os.Unknown -> throw UnsupportedOperationException("Unknown OS")

--- a/ci-helper/install-deps-windows.cmd
+++ b/ci-helper/install-deps-windows.cmd
@@ -2,8 +2,14 @@
 
 @REM 直接用 vcpkg install boost 也可以跑, 但是这会在 CI 上装一小时, 所以就只装了最少的能过编译的包
 
-vcpkg install openssl:x64-windows boost-variant:x64-windows boost-system:x64-windows boost-range:x64-windows boost-crc:x64-windows boost-logic:x64-windows boost-parameter:x64-windows boost-asio:x64-windows boost-variant2:x64-windows boost-multi-index:x64-windows boost-multiprecision:x64-windows
-@REM vcpkg install openssl:x64-windows boost:x64-windows
+if "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
+  set VCPKG_TRIPLET=arm64-windows
+) else (
+  set VCPKG_TRIPLET=x64-windows
+)
+
+vcpkg install openssl:%VCPKG_TRIPLET% boost-variant:%VCPKG_TRIPLET% boost-system:%VCPKG_TRIPLET% boost-range:%VCPKG_TRIPLET% boost-crc:%VCPKG_TRIPLET% boost-logic:%VCPKG_TRIPLET% boost-parameter:%VCPKG_TRIPLET% boost-asio:%VCPKG_TRIPLET% boost-variant2:%VCPKG_TRIPLET% boost-multi-index:%VCPKG_TRIPLET% boost-multiprecision:%VCPKG_TRIPLET%
+@REM vcpkg install openssl:%VCPKG_TRIPLET% boost:%VCPKG_TRIPLET%
 
 choco install swig -y
 choco install openssl -y


### PR DESCRIPTION
## 摘要

这个 PR 为 anitorrent 增加 Windows ARM64 native runtime artifact。

新增的 GitHub-hosted Windows ARM64 job 会使用 MSVC ARM64 和 vcpkg `arm64-windows` 构建 native library，上传 `anitorrent-windows-aarch64` artifact，并接入 release workflow，使 Maven publication 包含 `windows-arm64` classifier。

## 改动

- 在 build / release 矩阵中新增 `windows-11-arm` runner。
- Windows 下按架构选择 vcpkg triplet 和 Boost include path。
- Windows ARM64 构建时向 CMake 传入 `-DVCPKG_TARGET_TRIPLET=arm64-windows` 和 `-A ARM64`。
- native runtime classifiers 增加 `windows-arm64`。
- 打包 native jar 时兼容现代 CMake/vcpkg 暴露的 OpenSSL cache key：
  - `OPENSSL_CRYPTO_LIBRARY`
  - `OPENSSL_SSL_LIBRARY`
- 在 Windows ARM64 job 中安装 Android SDK platform，避免 Android Gradle Plugin 配置阶段缺少 SDK。
- 保持现有 Windows x64 行为不变。

## 验证

已在 Windows ARM64 本机验证：

```powershell
.\gradlew.bat buildAnitorrent copyNativeJarForCurrentPlatform `
  --no-configuration-cache `
  -Dani.enable.anitorrent=true `
  -DCMAKE_BUILD_TYPE=Release `
  -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake `
  -DBoost_INCLUDE_DIR=C:/vcpkg/installed/arm64-windows/include `
  -Pani.android.abis=arm64-v8a
```

生成的 `windows-arm64` native jar 包含：

- `anitorrent.dll`
- `torrent-rasterbar.dll`
- `libcrypto-3-arm64.dll`
- `libssl-3-arm64.dll`

也验证了：

```powershell
kotlin .github\workflows\src.main.kts
git diff --check
```

## 说明

Windows ARM64 CI job 只构建 native runtime artifact，不运行完整 Gradle `check`。原因是 `check` 会触发 desktop Kotlin target，而该 target 当前需要 JDK 8 toolchain；Windows ARM64 GitHub-hosted runner 上没有可用的 JDK 8 toolchain。现有 x64 / Linux / macOS jobs 仍继续运行正常检查。

`src.main.kts` 是 workflow 源文件，`build.yml` / `release.yml` 是生成结果；本 PR 同时提交生成后的 YAML。